### PR TITLE
Interpolate price data only

### DIFF
--- a/planetwatch/core.py
+++ b/planetwatch/core.py
@@ -119,8 +119,8 @@ class Wallet(object):
                 transactions.reward == True
             ]
             .merge(prices[[f"initial price {currency}", "date", "hour"]], how="left")
-            .interpolate()
         )
+        results[f"initial price {currency}"] = results[f"initial price {currency}"].interpolate()
         current_price = self.get_current_price()[currency]
         results[f"current value {currency}"] = current_price * results["amount"]
         results[f"initial value {currency}"] = (


### PR DESCRIPTION
Pandas doesn't seem to like interpolating one of the columns in the merged transaction and price data dataframe (likely the datetime64ns column that was added in 446f6ca, as determined by bisecting the recent changes). This seems to generate the error seen below (running on macOS 12.1 (M1/arm64) with python 3.8.9 installed using the instructions in the README):

```
% planets --wallet GYLEOJFHACSCATPBVQ345UCMCOMSGV76X4XTVOLHGXKOCJL44YBUAHXJOY --currency usd      
Traceback (most recent call last):
  File "/Users/curtis/Library/Python/3.8/bin/planets", line 8, in <module>
    sys.exit(cli())
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/planetwatch/core.py", line 149, in cli
    results, current_price = planet_wallet.get_cost(currency, prices)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/planetwatch/core.py", line 118, in get_cost
    transactions[["transaction", "timestamp", "amount", "date", "hour"]][
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/util/_decorators.py", line 311, in wrapper
    return func(*args, **kwargs)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/core/frame.py", line 10712, in interpolate
    return super().interpolate(
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/core/generic.py", line 6899, in interpolate
    new_data = obj._mgr.interpolate(
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/core/internals/managers.py", line 377, in interpolate
    return self.apply("interpolate", **kwargs)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/core/internals/managers.py", line 327, in apply
    applied = getattr(b, f)(**kwargs)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/core/internals/blocks.py", line 1369, in interpolate
    new_values = values.fillna(value=fill_value, method=method, limit=limit)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/core/arrays/_mixins.py", line 218, in fillna
    value, method = validate_fillna_kwargs(
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/util/_validators.py", line 372, in validate_fillna_kwargs
    method = clean_fill_method(method)
  File "/Users/curtis/Library/Python/3.8/lib/python/site-packages/pandas/core/missing.py", line 120, in clean_fill_method
    raise ValueError(f"Invalid fill method. Expecting {expecting}. Got {method}")
ValueError: Invalid fill method. Expecting pad (ffill) or backfill (bfill). Got linear
```

This pull request limits the interpolation to the "initial price" column and seems to fix the error.